### PR TITLE
Allow builds with base 4.9

### DIFF
--- a/MonadStack.cabal
+++ b/MonadStack.cabal
@@ -20,7 +20,7 @@ library
   exposed-modules:     Control.Monad.MonadStack
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >=4.7 && <4.9,
+  build-depends:       base >=4.7 && <4.10,
                        mtl >= 2.0 && <2.3
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
Hi, with this PR the package requires base >= 4.7 && < 4.10.  I think this should just work.  The package builds on my system with ghc 8.0.1